### PR TITLE
Added support for multiline headers.

### DIFF
--- a/multipart_parser.c
+++ b/multipart_parser.c
@@ -160,6 +160,11 @@ size_t multipart_parser_execute(multipart_parser* p, const char *buf, size_t len
           break;
         }
 
+        if (c == ' ' || c == '\t') {
+          p->state = s_header_value_start;
+          break;
+        }
+
         if (c == '-') {
           break;
         }
@@ -190,7 +195,7 @@ size_t multipart_parser_execute(multipart_parser* p, const char *buf, size_t len
 
       case s_header_value_start:
         multipart_log("s_header_value_start");
-        if (c == ' ') {
+        if (c == ' ' || c == '\t') {
           break;
         }
 


### PR DESCRIPTION
Bit of a tradeoff here.  I decided to just send additional lines with no
separator from previous lines.  One could send newlines with all header
values, the way part data works, but that could possibly be a breaking
change.  One could also add additional states, rewind the index and add
newlines only on multiline headers, but that seemed like too much
complexity.

This patch is meant to resolve #14.
