### PR TITLE
Makefile target for shared library build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,11 @@
-CFLAGS?=-std=c89 -ansi -pedantic -O4 -Wall
+CFLAGS?=-std=c89 -ansi -pedantic -O4 -Wall -fPIC 
 
 default: multipart_parser.o
 
 multipart_parser.o: multipart_parser.c multipart_parser.h
 
+solib: multipart_parser.o
+	$(CC) -shared -Wl,-soname,libmultipart.so -o libmultipart.so multipart_parser.o
+
 clean:
-	rm -f *.o
+	rm -f *.o *.so


### PR DESCRIPTION
I added a Makefile target in order to do a very simple shared library build.

If there's any demand, I could also create an autoconf-based solution.
